### PR TITLE
textlint関連のパッケージ削除

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -18,8 +18,6 @@
     "ja-hiragana-fukushi": true,
     "ja-hiragana-hojodoushi": true,
     "ja-hiragana-keishikimeishi": true,
-    "ja-unnatural-alphabet": true,
-    "ng-word": true,
     "no-dead-link": true,
     "no-mixed-zenkaku-and-hankaku-alphabet": true,
     "prefer-tari-tari": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,18 +14,14 @@
         "textlint-rule-abbr-within-parentheses": "1.0.2",
         "textlint-rule-footnote-order": "1.0.3",
         "textlint-rule-general-novel-style-ja": "dev-hato/textlint-rule-general-novel-style-ja-markdown",
-        "textlint-rule-helper": "2.3.0",
         "textlint-rule-ja-hiragana-fukushi": "1.3.0",
         "textlint-rule-ja-hiragana-hojodoushi": "1.1.0",
         "textlint-rule-ja-hiragana-keishikimeishi": "1.1.0",
-        "textlint-rule-ja-unnatural-alphabet": "2.0.1",
-        "textlint-rule-ng-word": "1.0.0",
         "textlint-rule-no-dead-link": "5.1.2",
         "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "1.0.1",
         "textlint-rule-prefer-tari-tari": "1.0.3",
         "textlint-rule-preset-ja-spacing": "2.3.0",
         "textlint-rule-preset-ja-technical-writing": "7.0.0",
-        "textlint-rule-preset-jtf-style": "2.3.13",
         "textlint-rule-terminology": "3.0.4"
       }
     },
@@ -12160,12 +12156,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/textlint-rule-ng-word": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ng-word/-/textlint-rule-ng-word-1.0.0.tgz",
-      "integrity": "sha1-s4miOepLSZL0VeKvNrsGL8bkLTk=",
-      "dev": true
-    },
     "node_modules/textlint-rule-no-dead-link": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/textlint-rule-no-dead-link/-/textlint-rule-no-dead-link-5.1.2.tgz",
@@ -23528,12 +23518,6 @@
           }
         }
       }
-    },
-    "textlint-rule-ng-word": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ng-word/-/textlint-rule-ng-word-1.0.0.tgz",
-      "integrity": "sha1-s4miOepLSZL0VeKvNrsGL8bkLTk=",
-      "dev": true
     },
     "textlint-rule-no-dead-link": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -9,18 +9,14 @@
     "textlint-rule-abbr-within-parentheses": "1.0.2",
     "textlint-rule-footnote-order": "1.0.3",
     "textlint-rule-general-novel-style-ja": "dev-hato/textlint-rule-general-novel-style-ja-markdown",
-    "textlint-rule-helper": "2.3.0",
     "textlint-rule-ja-hiragana-fukushi": "1.3.0",
     "textlint-rule-ja-hiragana-hojodoushi": "1.1.0",
     "textlint-rule-ja-hiragana-keishikimeishi": "1.1.0",
-    "textlint-rule-ja-unnatural-alphabet": "2.0.1",
-    "textlint-rule-ng-word": "1.0.0",
     "textlint-rule-no-dead-link": "5.1.2",
     "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "1.0.1",
     "textlint-rule-prefer-tari-tari": "1.0.3",
     "textlint-rule-preset-ja-spacing": "2.3.0",
     "textlint-rule-preset-ja-technical-writing": "7.0.0",
-    "textlint-rule-preset-jtf-style": "2.3.13",
     "textlint-rule-terminology": "3.0.4"
   }
 }


### PR DESCRIPTION
`textlint-rule-ja-unnatural-alphabet` と `textlint-rule-preset-jtf-style` は `textlint-rule-preset-ja-technical-writing` に包括されているので直接インストールしない形にします。
また、 `textlint-rule-helper` はruleに依存しているので直接インストールしない形にします。

https://github.com/KeitaMoromizato/textlint-rule-ng-word

また、`textlint-rule-ng-word` のリポジトリはpublic archiveになっているので削除します。