### PR TITLE
node-fetchダウングレード

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
         "@types/js-yaml": "4.0.9",
         "esbuild": "0.25.5",
+        "node-fetch": "2.6.12",
         "prettier": "3.5.3",
         "textlint": "15.0.1",
         "textlint-filter-rule-comments": "1.2.2",
@@ -5284,9 +5285,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
     "@types/js-yaml": "4.0.9",
     "esbuild": "0.25.5",
+    "node-fetch": "2.6.12",
     "prettier": "3.5.3",
     "textlint": "15.0.1",
     "textlint-filter-rule-comments": "1.2.2",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>dev-hato/renovate-config"]
+  "extends": ["github>dev-hato/renovate-config"],
+  "ignoreDeps": ["node-fetch"]
 }


### PR DESCRIPTION
https://github.com/dev-hato/github-actions-cache-cleaner/pull/1372, https://github.com/dev-hato/github-actions-cache-cleaner/pull/1375 でsuper-linterの実行が終わらなくなっているので、 https://github.com/dev-hato/hato-atama/pull/3551 と同様に `node-fetch` を2.6.12で固定します。