### PR TITLE
actions/github-scriptアップデート

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -41,7 +41,7 @@ jobs:
           result-encoding: string
           script: |
             const {tsImport} = require('tsx/esm/api')
-            const {script} = await tsImport(
+            const {default: {script}} = await tsImport(
               './scripts/update_readme/update_readme/get_inputs_markdown.ts',
               process.env.GITHUB_WORKSPACE + '/'
             )

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Get inputs markdown
         id: get_inputs_markdown
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref || github.head_ref}}
         with:

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         github-token: ${{inputs.github-token}}
         script: |


### PR DESCRIPTION
https://github.com/dev-hato/github-actions-cache-cleaner/pull/1435 をベースに `actions/github-script` をアップデートします。
scriptの宣言方法を修正しています。