### PR TITLE
CI Lint Code Base: PRへの書き込み権限付与

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: read
   packages: read
+  pull-requests: write
   statuses: write
 ###############
 # Set the Job #


### PR DESCRIPTION
https://github.com/dev-hato/github-actions-cache-cleaner/actions/runs/24280486308/job/70901506137#step:6:443

```
2026-04-11 10:26:17 [WARN]   Failed to call GitHub API (https://api.github.com/repos/dev-hato/github-actions-cache-cleaner/issues/1657/comments): curl: (22) The requested URL returned error: 403
```

上記Warningを解消するため、CI `Lint Code Base` に `pull-requests: write` を付与します。