### PR TITLE
textlint-rule-preset-ja-spacingアップデート

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ jobs:
 
 ### 設定
 
-<https://pre-commit.com/> の手順に従って `pre-commit` をインストールします。  
+<https://pre-commit.com/>の手順に従って`pre-commit`をインストールします。  
 これにより、コミット時にクレデンシャルが含まれていないかの検査が行われるようになります。

--- a/README.template.md
+++ b/README.template.md
@@ -31,5 +31,5 @@ ${INPUTS}
 
 ### 設定
 
-<https://pre-commit.com/> の手順に従って `pre-commit` をインストールします。  
+<https://pre-commit.com/>の手順に従って`pre-commit`をインストールします。  
 これにより、コミット時にクレデンシャルが含まれていないかの検査が行われるようになります。

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "textlint-rule-no-dead-link": "6.2.2",
         "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "1.0.1",
         "textlint-rule-prefer-tari-tari": "1.0.3",
-        "textlint-rule-preset-ja-spacing": "2.4.3",
+        "textlint-rule-preset-ja-spacing": "3.0.0",
         "textlint-rule-preset-ja-technical-writing": "12.0.2",
         "textlint-rule-terminology": "5.2.16",
         "tsc": "2.0.4",
@@ -6723,9 +6723,9 @@
       }
     },
     "node_modules/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/-/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana-2.4.3.tgz",
-      "integrity": "sha512-xIpEAgpaPTnavzCMLcSB/tlZ3Tq9paclyyMEgAQxkM9adv8TrwddZ+Ys+BSd4zjuVa94NED0bajYWtahSjZ53g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/-/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana-3.0.0.tgz",
+      "integrity": "sha512-tyrHoTEuaW5BqoGsePJhYw07OmH5LhWpx2g8eWfVeaDfQJITJKS3mSXdOGhN++8Y+EkTAx7Z/ePIjBxJTGNcFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6851,24 +6851,22 @@
       }
     },
     "node_modules/textlint-rule-ja-no-space-around-parentheses": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-around-parentheses/-/textlint-rule-ja-no-space-around-parentheses-2.4.2.tgz",
-      "integrity": "sha512-DmmWEKu2hFJs/C4Ruxm/Zkp5gc9W+8kTgUULx54J00MJyJgLWm0XY9BH3OdN66+4+3BFutvxzCLU9y/M1+Dx7w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-around-parentheses/-/textlint-rule-ja-no-space-around-parentheses-3.0.0.tgz",
+      "integrity": "sha512-vrNIrZa8cx8Yw5EIcE9uMqolM0xr9YUGhqtdB+yz2dQGV8Ptml7rSfUNFbPDDOYqjJE33bTD14dv5cjqfHo1vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.3",
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-no-space-between-full-width": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-between-full-width/-/textlint-rule-ja-no-space-between-full-width-2.4.2.tgz",
-      "integrity": "sha512-yDiZrJYX2cVO85tLw+ojUntky44ijEfIX2sWinIEN0IdYMCINjYwmgRYFmnqwQ+MZyo+foAt2vLUZtaSZlk/Lw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-between-full-width/-/textlint-rule-ja-no-space-between-full-width-3.0.0.tgz",
+      "integrity": "sha512-Awhbyex7x26OnQmvbGNUZ2PF5RaH2fKHAM8SkxGyXK/IfCN1P7vnoGKk4ud6CWlEx6yKHDOJ0D9/2KgkZQr1sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.3",
         "regx": "^1.0.4",
         "textlint-rule-helper": "^2.2.4"
       }
@@ -6922,58 +6920,73 @@
       }
     },
     "node_modules/textlint-rule-ja-space-after-exclamation": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-exclamation/-/textlint-rule-ja-space-after-exclamation-2.4.2.tgz",
-      "integrity": "sha512-3qH0aIG48MrA8qhcljGSGxPmvrrmOQsP/kTfj8SGDKdkBUs05z1x1bgw106RVNVv1enz2v+ZafuVdgFViRKWfA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-exclamation/-/textlint-rule-ja-space-after-exclamation-3.0.0.tgz",
+      "integrity": "sha512-iYv5G8Tvi3KmycvkY4Fd8byqkfFwp8lm1uB2On8chu55HYDhJ4EqKV2TZRQlJX5kNZk4+zKkrI1yiFTaUCQ80g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.3",
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-after-question": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-question/-/textlint-rule-ja-space-after-question-2.4.2.tgz",
-      "integrity": "sha512-ie1R03y1606QApXu+ZF6X+bAJLccRy/lA5JityfTO9M4EM+7ENMle9fTMoEEKJkNkjHaLi530IzqAZ+CLEe8Qw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-question/-/textlint-rule-ja-space-after-question-3.0.0.tgz",
+      "integrity": "sha512-KYId9c6wTgVfIyJkbnlEkWpOpLKfdyYbZXIyjjAqZvfY8WOEttWLO6LCpbOooyIP+ZS6tqxaY4Q1gmIQD1wbPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.1",
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-around-code": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-code/-/textlint-rule-ja-space-around-code-2.4.2.tgz",
-      "integrity": "sha512-DM4OF7seafTKrxPFjUJyxx/lwlg8CO3wgwmTJWhQ+6po3mQVV6QaBHpc0861/32kUAJm1ZgRpiBlDWUdraXFFA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-code/-/textlint-rule-ja-space-around-code-3.0.0.tgz",
+      "integrity": "sha512-7gNOYLGBhrFjnkYlPU5MUN/Wp/nAyWxqdzcbsv7Jm+80m7kXDymC2TbrnNImC1AF87YgRGgX4OsgmoTnvsZppg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.1",
+        "textlint-rule-helper": "^2.2.4"
+      }
+    },
+    "node_modules/textlint-rule-ja-space-around-emphasis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-emphasis/-/textlint-rule-ja-space-around-emphasis-3.0.0.tgz",
+      "integrity": "sha512-1BZmoVXfhJqJqONGiaMF13PqIvRAVD3f8/ziDvT3OLNXHhGuvVhaeEKXTnzMGHOeYbkqYjunSwjEArumVT9mVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-around-link": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-link/-/textlint-rule-ja-space-around-link-2.4.2.tgz",
-      "integrity": "sha512-++o4wwCnDiubgE60QuOv0xW/0EcF2ta4EfjOycYsLYqvJ6DzFEZFGv3S/TujzmrIdRc8sHAO62489flvPu1DsQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-link/-/textlint-rule-ja-space-around-link-3.0.0.tgz",
+      "integrity": "sha512-qExiAO25+tE/KZdi/JaumDuuyZ13Ed4oZG1tnjUNA/6n8hpm9wg9nFU9xQ4feBW7r43lwD5VW99W0qk+eoNs8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.1",
+        "textlint-rule-helper": "^2.2.4"
+      }
+    },
+    "node_modules/textlint-rule-ja-space-around-strong": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-strong/-/textlint-rule-ja-space-around-strong-3.0.0.tgz",
+      "integrity": "sha512-6SN0Ax3j3cqdJmyRyQtQRjcd6AyGW0nuk6/ffsZyFoodu2QjBcUcMQgFcEsPrp1YINkedHCcQ4pqmk9OZYHkGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-between-half-and-full-width": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-between-half-and-full-width/-/textlint-rule-ja-space-between-half-and-full-width-2.4.2.tgz",
-      "integrity": "sha512-GqwSy0ivm4Q5Bok9LaOwfg+H1auLRMoMi2aY/7aSIrgvX/RD5aZ2Rk2lm3TTX42mR1UrQu8GDqktUEZfvQ913w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-between-half-and-full-width/-/textlint-rule-ja-space-between-half-and-full-width-3.0.0.tgz",
+      "integrity": "sha512-L1pxdF5TzhyAgwEjpI7fOkOgxVSclEHKW7UsLG6dQPRxzhdFs9ewWAsN4unYXtwpixWgqjYKTOQwClUT2Eb03g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@textlint/regexp-string-matcher": "^2.0.2",
-        "match-index": "^1.0.1",
         "textlint-rule-helper": "^2.2.4"
       }
     },
@@ -7499,20 +7512,22 @@
       }
     },
     "node_modules/textlint-rule-preset-ja-spacing": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-spacing/-/textlint-rule-preset-ja-spacing-2.4.3.tgz",
-      "integrity": "sha512-WAiWY9TOE8/bRdl14XJdjkPQcV0hLS4O+PCUYU1yxXmJhZ8V3ciw2GYqpA9GL73qAxL25UD6mkf1yfz6aJ4qSA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-spacing/-/textlint-rule-preset-ja-spacing-3.0.0.tgz",
+      "integrity": "sha512-Tbx0Nz6t5ZEYz9nSpiaBZp/GCBfKGVT6UrunlKDdT1GlHwgMbojX7vIXgxV789wKcH1d452eIb9uNAhUq3N8NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": "^2.4.3",
-        "textlint-rule-ja-no-space-around-parentheses": "^2.4.2",
-        "textlint-rule-ja-no-space-between-full-width": "^2.4.2",
-        "textlint-rule-ja-space-after-exclamation": "^2.4.2",
-        "textlint-rule-ja-space-after-question": "^2.4.2",
-        "textlint-rule-ja-space-around-code": "^2.4.2",
-        "textlint-rule-ja-space-around-link": "^2.4.2",
-        "textlint-rule-ja-space-between-half-and-full-width": "^2.4.2"
+        "textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": "^3.0.0",
+        "textlint-rule-ja-no-space-around-parentheses": "^3.0.0",
+        "textlint-rule-ja-no-space-between-full-width": "^3.0.0",
+        "textlint-rule-ja-space-after-exclamation": "^3.0.0",
+        "textlint-rule-ja-space-after-question": "^3.0.0",
+        "textlint-rule-ja-space-around-code": "^3.0.0",
+        "textlint-rule-ja-space-around-emphasis": "^3.0.0",
+        "textlint-rule-ja-space-around-link": "^3.0.0",
+        "textlint-rule-ja-space-around-strong": "^3.0.0",
+        "textlint-rule-ja-space-between-half-and-full-width": "^3.0.0"
       }
     },
     "node_modules/textlint-rule-preset-ja-technical-writing": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "textlint-rule-no-dead-link": "6.2.2",
     "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "1.0.1",
     "textlint-rule-prefer-tari-tari": "1.0.3",
-    "textlint-rule-preset-ja-spacing": "2.4.3",
+    "textlint-rule-preset-ja-spacing": "3.0.0",
     "textlint-rule-preset-ja-technical-writing": "12.0.2",
     "textlint-rule-terminology": "5.2.16",
     "tsc": "2.0.4",


### PR DESCRIPTION
https://github.com/dev-hato/github-actions-cache-cleaner/pull/1703 をベースにtextlint-rule-preset-ja-spacingをアップデートします。