### PR TITLE
Restrict pull request workflows to main

### DIFF
--- a/.github/workflows/add-to-task-list.yml
+++ b/.github/workflows/add-to-task-list.yml
@@ -1,6 +1,8 @@
 name: Add to Task List
 on:
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - reopened

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -2,6 +2,8 @@
 name: format-json-yml
 on:
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - synchronize

--- a/.github/workflows/github-actions-cache-cleaner.yml
+++ b/.github/workflows/github-actions-cache-cleaner.yml
@@ -8,6 +8,8 @@ on:
     - cron: "0 21 * * *" # 06:00 JST
   workflow_dispatch:
   pull_request:
+    branches:
+      - main
     paths:
       - .github/workflows/github-actions-cache-cleaner.yml
       - dist/**

--- a/.github/workflows/github-actions-cache-cleaner.yml
+++ b/.github/workflows/github-actions-cache-cleaner.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
     paths:
       - .github/workflows/github-actions-cache-cleaner.yml
       - dist/**

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -18,6 +18,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -20,6 +20,10 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -2,6 +2,8 @@
 name: update-dist
 on:
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - synchronize

--- a/.github/workflows/update-gitleaks.yml
+++ b/.github/workflows/update-gitleaks.yml
@@ -2,6 +2,8 @@
 name: update-gitleaks
 on:
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - synchronize

--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -2,6 +2,8 @@
 name: update-package
 on:
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - synchronize

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -2,6 +2,8 @@
 name: update-readme
 on:
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - synchronize


### PR DESCRIPTION
## Summary

- Restrict all eight pull request-triggered workflows to pull requests targeting `main`.
- Make pull request activity types explicit for workflows that use the default `opened`, `synchronize`, and `reopened` events.
- Keep `closed` handling only in workflows that perform explicit close-event processing.

## Root cause

The workflows used inconsistent `pull_request` filters. Some lacked a base-branch filter, while others relied on implicit activity-type defaults, making the intended trigger behavior difficult to audit.

## Validation

- `git diff --check`
- Verified every `pull_request` trigger in `.github/workflows` has `branches: - main`.
- Verified the activity types are explicit and appropriate to each workflow's behavior.
