### PR TITLE
非推奨の tsc 依存を削除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "textlint-rule-preset-ja-spacing": "3.0.2",
         "textlint-rule-preset-ja-technical-writing": "12.0.2",
         "textlint-rule-terminology": "5.2.16",
-        "tsc": "2.0.4",
         "tsx": "4.23.1",
         "typescript": "7.0.2"
       },
@@ -8555,17 +8554,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/tsc": {
-      "version": "2.0.4",
-      "resolved": "https://npm.flatt.tech/tsc/-/tsc-2.0.4.tgz",
-      "integrity": "sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsc": "bin/tsc"
       }
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "textlint-rule-preset-ja-spacing": "3.0.2",
     "textlint-rule-preset-ja-technical-writing": "12.0.2",
     "textlint-rule-terminology": "5.2.16",
-    "tsc": "2.0.4",
     "tsx": "4.23.1",
     "typescript": "7.0.2"
   },


### PR DESCRIPTION
## 概要

- 非推奨の `tsc@2.0.4` devDependency を削除
- `package-lock.json` から該当パッケージのエントリを削除
- ビルドで使用する `tsc` CLI を提供する `typescript@7.0.2` は維持

## 変更理由

Renovate が `tsc@2.0.4` を deprecated として報告しています。リポジトリには既に `typescript` が依存関係として存在し、両方のパッケージが `tsc` バイナリを提供していました。冗長なパッケージを削除することで warning を解消し、使用されるコンパイラの曖昧さをなくします。

## 検証

- `npm install --package-lock-only --ignore-scripts --no-audit --no-fund`
- `npm ci --ignore-scripts --no-audit --no-fund`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

なお、install 時には今回の変更とは無関係な `inflight`、`glob`、およびローカル Node.js バージョンに関する既存 warning が出力されました。
